### PR TITLE
Quick Fix for Issues with POSTing Edits

### DIFF
--- a/templates/edit.tmpl
+++ b/templates/edit.tmpl
@@ -15,6 +15,8 @@
             <label for="message">Description of Changes:</label>
             <input type="text" name="message" id="rstwiki-message" style="width:75%">
         </div>
+		
+		<input type="hidden" name="action" value="edit">
         
         <button type='submit'>Save</button> 
         <button type='reset' id='rstwiki-canceler'>Cancel</button>


### PR DESCRIPTION
Missing kwargs['action'] from edit page
