### PR TITLE
Changes to CodeGlass to add support for dojox/mobile live examples

### DIFF
--- a/_static/docs/MiniGlass.js
+++ b/_static/docs/MiniGlass.js
@@ -116,7 +116,7 @@ define([
 					.replace(/[\s+]?<\/script>/g, "")
 				;
 			}else if(type == "css" && openswith != "<"){
-				orig = '<style type="text/css">' + orig + '</style>';
+				orig = '<style type="text/css">\n' + orig + '\n\t</style>';
 			}
 
 			this.parts[type].push(orig)
@@ -133,20 +133,26 @@ define([
 			uri.href = this.domNode.ownerDocument.URL;
 
 			var templateParts = {
-				javascript: (dojoConfig ? scriptopen + "dojoConfig = {" + dojoConfig + "}" + scriptclose : "") +
-					"<scr" + "ipt src='" + (has("ie") ? config.cdn ? config.cdn + "dojo/" : config.baseUrl : config.baseUrl) +
-					"dojo.js'>" + scriptclose,
+				javascript: (dojoConfig ? "\t" + scriptopen + "dojoConfig = {" + dojoConfig + "}" + scriptclose + "\n" : "") +
+					"\t<scr" + "ipt src='" + (has("ie") ? config.cdn ? config.cdn + "dojo/" : config.baseUrl : config.baseUrl) +
+					"dojo.js'>" + scriptclose + "\n\t",
 				
 				htmlcode:"", 
 				
 				// if we have a theme set include a link to {baseUrl}/dijit/themes/{themename}/{themename}.css first
-				css:'\t<link rel="stylesheet" href="' + this.baseUrl + 'dijit/themes/' + this.themename + '/' + this.themename + '.css">\n\t',
+				// For the Dojo Mobile case, in Dojo 1.8+, if the specified theme is "deviceTheme" generate
+				// a script tag to import deviceTheme.js.
+				css: this.themename == "deviceTheme" ?
+					'\t<script type="text/javascript" src="' + this.baseUrl + 'dojox/mobile/deviceTheme.js"></script>\n\t' :
+					'\t<link rel="stylesheet" href="' + this.baseUrl + 'dijit/themes/' + this.themename + '/' + this.themename + '.css">\n\t',
 				
 				// if we've set RTL include dir="rtl" i guess?
 				htmlargs:"",
 				
 				// if we have a theme set, include class="{themename}"
-				bodyargs:'class="' + this.themename + '"',
+				bodyargs: this.themename == "deviceTheme" ? 
+					'style=\"visibility:hidden;\"' :
+					'class="' + this.themename + '"',
 				
 				// 
 				head:""
@@ -166,7 +172,7 @@ define([
 					var processed = lang.replace(item, locals, cgMiniRe);
 					switch(i){
 						case "javascript":
-							templateParts.javascript += scriptopen + processed + scriptclose;
+							templateParts.javascript += "\n\t" + scriptopen + "\n" + processed + "\n\t" + scriptclose;
 							break;
 						case "html":
 							templateParts['htmlcode'] += processed;

--- a/src/dojo.py
+++ b/src/dojo.py
@@ -639,13 +639,14 @@ class DojoHTMLTranslator(HTMLTranslator):
 
     def visit_codeviewer_compound(self, node):
         # testing. switch to CodeGlass.base and require() it for backwards compat for now
-        self.body.append('<div data-dojo-type="docs.MiniGlass" class="CodeGlassMini" data-dojo-props="type: \'%s\', pluginArgs:{ djConfig: \'%s\', version:\'%s\' }, width:\'%s\', height:\'%s\', toolbar:\'%s\'"><div class="CodeGlassMiniInner">' % (
+        self.body.append('<div data-dojo-type="docs.MiniGlass" class="CodeGlassMini" data-dojo-props="type: \'%s\', pluginArgs:{ djConfig: \'%s\', version:\'%s\' }, width:\'%s\', height:\'%s\', toolbar:\'%s\', themename:\'%s\'"><div class="CodeGlassMiniInner">' % (
             node['type'].lower(),
             node['djconfig'],
             node['version'],
             node['width'],
             node['height'],
-            node['toolbar'])
+            node['toolbar'],
+            node['theme'])
         )
 
     def depart_codeviewer_compound(self, node):
@@ -766,6 +767,10 @@ def _codeviewer_compound(name, arguments, options, content, lineno,
     if 'toolbar' in options:
         toolbar = options['toolbar']
     node['toolbar'] = toolbar
+    theme = "claro"
+    if 'theme' in options:
+        theme = options['theme']
+    node['theme'] = theme
     state.nested_parse(content, content_offset, node)
     return [node]
 


### PR DESCRIPTION
Changes to CodeGlass to add support for Dojo Mobile live examples: when the 'theme' param. of code-example is "deviceTheme", it imports dojox/mobile/deviceTheme.js using <script> instead of importing dijit's claro.css, and adds the hidden visibility style on <body> instead of setting the claro class.  Secondarily, improvements of the formatting/indentation of the generated source 
