### PR TITLE
Changes to add support for dojox/mobile CodeGlass live examples

### DIFF
--- a/export/source/_ext/dojocodeglass.py
+++ b/export/source/_ext/dojocodeglass.py
@@ -28,13 +28,14 @@ class DojoHTMLTranslator(SmartyPantsHTMLTranslator):
         self.body.append('</pre></div>')
 
     def visit_codeviewer_compound(self, node):
-        self.body.append('<div data-dojo-type="CodeGlass.base" type="%s" pluginArgs="{dojoConfig:\'%s\', version:\'%s\'}" width="%s" height="%s" toolbar="%s">' % (
+        self.body.append('<div data-dojo-type="CodeGlass.base" data-dojo-props="type: \'%s\', pluginArgs:{ dojoConfig: \'%s\', version:\'%s\' }, width:\'%s\', height:\'%s\', toolbar:\'%s\', themename:\'%s\'">' % (
             node['type'].lower(),
             node['djconfig'],
             node['version'],
             node['width'],
             node['height'],
-            node['toolbar'])
+            node['toolbar'],
+            node['theme'])
         )
 
     def depart_codeviewer_compound(self, node):
@@ -140,6 +141,10 @@ def _codeviewer_compound(name, arguments, options, content, lineno,
     if 'toolbar' in options:
         toolbar = options['toolbar']
     node['toolbar'] = toolbar
+    theme = "claro"
+    if 'theme' in options:
+        theme = options['theme']
+    node['theme'] = theme
     state.nested_parse(content, content_offset, node)
     return [node]
 

--- a/export/source/_ext/dojowiki.py
+++ b/export/source/_ext/dojowiki.py
@@ -33,13 +33,14 @@ class DojoHTMLTranslator(SmartyPantsHTMLTranslator):
         self.body.append('</textarea></div>')
 
     def visit_codeviewer_compound(self, node):
-        self.body.append('<div data-dojo-type="docs.MiniGlass" class="CodeGlassMini" type="%s" pluginArgs="{dojoConfig:\'%s\', version:\'%s\'}" width="%s" height="%s" toolbar="%s"><div class="CodeGlassMiniInner">' % (
+        self.body.append('<div data-dojo-type="docs.MiniGlass" class="CodeGlassMini" data-dojo-props="type: \'%s\', pluginArgs:{ dojoConfig: \'%s\', version:\'%s\' }, width:\'%s\', height:\'%s\', toolbar:\'%s\', themename:\'%s\'"><div class="CodeGlassMiniInner">' % (
             node['type'].lower(),
             node['djconfig'],
             node['version'],
             node['width'],
             node['height'],
-            node['toolbar'])
+            node['toolbar'],
+            node['theme'])
         )
 
     def depart_codeviewer_compound(self, node):


### PR DESCRIPTION
Follow-up of e761077955264eedf73f1e1ca8b0299b759bea48
For the .py part of this older PR/commit, it appears that the .py code used for the static generation of HTML is different than the one used for the live generation (for instance on livedocs).
Hence, adapted the previous changes in src/dojo.py to dojocodeglass.py and dojowiki.py from export/source/_ext. 
Important: I tried to test these changes using the instructions at http://livedocs.dojotoolkit.org/developer/metadoc#creating-reference-guide-for-web-site, but on my Windows machine (under cygwin) it didn't work. Before going further it would need to be tested.
